### PR TITLE
Code Improvements and Support to native AWS Keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
-vendor/
+/composer.lock
+/node_modules
+/vendor
+.env
+/.idea
+/.vscode

--- a/src/SqsBase.php
+++ b/src/SqsBase.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace SqsSimple;
+
+class SqsBase {
+
+    public $SqsClient           = null;
+
+    /**
+     * SqsWorker constructor.
+     * @param array $AwsConfig
+     */
+    public function __construct(array $AwsConfig)
+    {        
+        $sharedConfig = [
+            'region'      => $AwsConfig['AWS_REGION'],
+            'version'     => $AwsConfig['API_VERSION'],
+        ];
+        
+        if (isset($AwsConfig['AWS_KEY']) && isset($AwsConfig['AWS_SECRET_KEY']))
+        {
+            $sharedConfig['credentials'] = new \Aws\Credentials\Credentials($AwsConfig['AWS_KEY'], $AwsConfig['AWS_SECRET_KEY']);
+        }
+
+        // Create an SDK class used to share configuration across clients.
+        $sdk = new \Aws\Sdk($sharedConfig);
+        
+        // Create an Amazon SQS client using the shared configuration data.
+        $this->SqsClient = $sdk->createSqs();
+    }
+
+    /**
+     * Set client
+     *
+     * @param $SqsClient
+     */
+    public function setClient($SqsClient)
+    {
+        $this->SqsClient = $SqsClient;
+    }
+    
+    /**
+     * Set params
+     *
+     * @param array $params
+     */
+    public function setParams(array $params)
+    {
+        foreach ($params as $param => $value) {
+            $this->{$param} = $value;
+        }
+    }
+}

--- a/src/SqsMessenger.php
+++ b/src/SqsMessenger.php
@@ -4,54 +4,10 @@ namespace SqsSimple;
 
 use Aws\Exception\AwsException;
 
-class SqsMessenger
-{
-    
-    public $SqsClient        = null;
+class SqsMessenger extends SqsBase
+{    
     public $RetryTimesOnFail = 2;
-    public $WaitBeforeRetry  = 1;
-    
-    /**
-     * SqsMessenger constructor.
-     * @param array $AwsConfig
-     */
-    public function __construct(array $AwsConfig)
-    {
-        $credentials  = new \Aws\Credentials\Credentials($AwsConfig['AWS_KEY'], $AwsConfig['AWS_SECRET_KEY']);
-        $sharedConfig = [
-            'credentials' => $credentials,
-            'region'      => $AwsConfig['AWS_REGION'],
-            'version'     => $AwsConfig['API_VERSION'],
-        ];
-        
-        // Create an SDK class used to share configuration across clients.
-        $sdk = new \Aws\Sdk($sharedConfig);
-        
-        // Create an Amazon SQS client using the shared configuration data.
-        $this->SqsClient = $sdk->createSqs();
-    }
-    
-    /**
-     * Set client
-     *
-     * @param $SqsClient
-     */
-    public function setClient($SqsClient)
-    {
-        $this->SqsClient = $SqsClient;
-    }
-    
-    /**
-     * Set params
-     *
-     * @param array $params
-     */
-    public function setParams(array $params)
-    {
-        foreach ($params as $param => $value) {
-            $this->{$param} = $value;
-        }
-    }
+    public $WaitBeforeRetry  = 1;    
     
     /**
      * Publish

--- a/src/SqsWorker.php
+++ b/src/SqsWorker.php
@@ -4,56 +4,13 @@ namespace SqsSimple;
 
 use Aws\Exception\AwsException;
 
-class SqsWorker
-{
-    public $SqsClient           = null;
+class SqsWorker extends SqsBase
+{    
     public $Sleep               = 10;
     public $WaitTimeSeconds     = 20;
     public $MaxNumberOfMessages = 1;
     public $VisibilityTimeout   = 3600;
-    public $workerProcess       = false;
-    
-    /**
-     * SqsWorker constructor.
-     * @param array $AwsConfig
-     */
-    public function __construct(array $AwsConfig)
-    {
-        $credentials  = new \Aws\Credentials\Credentials($AwsConfig['AWS_KEY'], $AwsConfig['AWS_SECRET_KEY']);
-        $sharedConfig = [
-            'credentials' => $credentials,
-            'region'      => $AwsConfig['AWS_REGION'],
-            'version'     => $AwsConfig['API_VERSION'],
-        ];
-        
-        // Create an SDK class used to share configuration across clients.
-        $sdk = new \Aws\Sdk($sharedConfig);
-        
-        // Create an Amazon SQS client using the shared configuration data.
-        $this->SqsClient = $sdk->createSqs();
-    }
-    
-    /**
-     * Set client
-     *
-     * @param $SqsClient
-     */
-    public function setClient($SqsClient)
-    {
-        $this->SqsClient = $SqsClient;
-    }
-    
-    /**
-     * Set params
-     *
-     * @param array $params
-     */
-    public function setParams(array $params)
-    {
-        foreach ($params as $param => $value) {
-            $this->{$param} = $value;
-        }
-    }
+    public $workerProcess       = false;    
     
     /**
      * Listener
@@ -199,7 +156,7 @@ class SqsWorker
             throw new \Exception("No SQS client defined");
         }
         
-        $result = $this->SqsClient->deleteMessage([
+        $this->SqsClient->deleteMessage([
             'QueueUrl'      => $this->queueUrl, // REQUIRED
             'ReceiptHandle' => $message['ReceiptHandle'], // REQUIRED
         ]);
@@ -217,7 +174,7 @@ class SqsWorker
             throw new \Exception("No SQS client defined");
         }
         
-        $result = $this->SqsClient->changeMessageVisibility([
+        $this->SqsClient->changeMessageVisibility([
             // VisibilityTimeout is required
             'VisibilityTimeout' => 0,
             'QueueUrl'          => $this->queueUrl, // REQUIRED


### PR DESCRIPTION
The idea of this PR is to optimize the code base (avoiding duplicate code using a base class that the other classes extend) and also to allow the code to run within environments where authentication is done through IAM Roles in AWS.

In the specific case where I had problems was in AWS ECS, where the permissions are "injected" through IAM Roles, so we don't have specific KEYS to inject into the code.
![carbon](https://user-images.githubusercontent.com/6741236/157298146-31108aad-75d8-4a80-b1e3-de3e20a099fd.png)

For this reason, I put a check to add the credentials only if they are informed, and this way, in contexts where the code runs in containers with IAM Roles, we won't have problems communicating with AWS.

@tedicela I look forward to your verification in this PR, and of course your comments are welcome.